### PR TITLE
Added the shell commands for shared_ip back

### DIFF
--- a/python_neutronclient_ip_address_extension.py
+++ b/python_neutronclient_ip_address_extension.py
@@ -112,9 +112,9 @@ class IPAddressesPorts(extension.NeutronClientExtension):
 
 
 class IPAddressesPortsList(extension.ClientExtensionList, IPAddressesPorts):
-    pass
+    shell_command = 'ip-addresses-ports-list'
 
 
 class IPAddressesPortsUpdate(extension.ClientExtensionUpdate,
                              IPAddressesPorts):
-    pass
+    shell_command = 'ip-addresses-ports-update'


### PR DESCRIPTION
JIRA:NCP-1840

Added them back for debugging purposes. While they are not necessarily
used by the average client, they will be used by developers.